### PR TITLE
Release v.1.2.0: fix binary path

### DIFF
--- a/Formula/chart-releaser.rb
+++ b/Formula/chart-releaser.rb
@@ -22,7 +22,7 @@ class ChartReleaser < Formula
   end
 
   def install
-    bin.install "chart-releaser"
+    bin.install "cr"
   end
 
   test do


### PR DESCRIPTION
## Reason
Currently, the installation process via brew fails with

```
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - chart-releaser
```